### PR TITLE
change linter name to valid in analysis.Validate()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# miss-inject
-the miss-inject is a Linter to prevent forgetting to inject dependency.
-When initializing the structure, the miss-inject check whether the structure field of the interface type has a value.
+# missinject
+the missinject is a Linter to prevent forgetting to inject dependency.  
+When initializing the structure, the missinject check whether the structure field of the interface type has a value.
 
 ## Installation
 ```
-go get -u github.com/theoden9014/miss-inject/cmd/miss-inject
+go get -u github.com/theoden9014/miss-inject/cmd/missinject
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
-module github.com/theoden9014/miss-inject
+module github.com/theoden9014/missinject
 
-go 1.14
+go 1.15
 
 require golang.org/x/tools v0.0.0-20200827010519-17fd2f27a9e3

--- a/missinject.go
+++ b/missinject.go
@@ -9,7 +9,7 @@ import (
 )
 
 var Analyzer = &analysis.Analyzer{
-	Name: "miss-inject",
+	Name: "missinject",
 	Doc:  Doc,
 	Run:  run,
 	Requires: []*analysis.Analyzer{
@@ -17,7 +17,7 @@ var Analyzer = &analysis.Analyzer{
 	},
 }
 
-const Doc = "miss-inject is a Linter to prevent forgetting to inject dependency"
+const Doc = "missinject is a Linter to prevent forgetting to inject dependency"
 
 func run(pass *analysis.Pass) (interface{}, error) {
 	inspect := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)

--- a/missinject_test.go
+++ b/missinject_test.go
@@ -3,11 +3,18 @@ package missinject_test
 import (
 	"testing"
 
-	"github.com/theoden9014/miss-inject"
+	"github.com/theoden9014/missinject"
+	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/analysistest"
 )
 
 func Test(t *testing.T) {
 	testdata := analysistest.TestData()
 	analysistest.Run(t, testdata, missinject.Analyzer, "a")
+}
+
+func TestValidate(t *testing.T) {
+	if err := analysis.Validate([]*analysis.Analyzer{missinject.Analyzer}); err != nil {
+		t.Errorf("failed to validate missinject.Analyzer: %v", err)
+	}
 }


### PR DESCRIPTION
## Feature
- Fix
  - change linter name to valid in analysis.Validate()